### PR TITLE
equals opperator needed to be double equals opperator (==)

### DIFF
--- a/job-posting/requirements.txt
+++ b/job-posting/requirements.txt
@@ -1,2 +1,2 @@
-python-dotenv=1.0.1
-crewai=0.14.3
+python-dotenv==1.0.1
+crewai==0.14.3


### PR DESCRIPTION
In "job-posting" example, I updated the equals operator in the requirements.txt file. I needed the double equals for it to run. 