### PR TITLE
Update requirements.txt for job-posting example

### DIFF
--- a/job-posting/requirements.txt
+++ b/job-posting/requirements.txt
@@ -1,2 +1,2 @@
-python-dotenv=1.0.1
-crewai=0.14.3
+python-dotenv==1.0.1
+crewai==0.14.3


### PR DESCRIPTION
The `requirements.txt` was missing a `=` causing the installation to fail.