### PR TITLE
Resolve wrong class name reference

### DIFF
--- a/job-posting/agents.py
+++ b/job-posting/agents.py
@@ -1,8 +1,8 @@
 from crewai import Agent
-from crewai_tools.tools import WebsiteSearchTool, SeperDevTool, FileReadTool
+from crewai_tools.tools import WebsiteSearchTool, SerperDevTool, FileReadTool
 
 web_search_tool = WebsiteSearchTool()
-seper_dev_tool = SeperDevTool()
+seper_dev_tool = SerperDevTool()
 file_read_tool = FileReadTool(
 	file_path='job_description_example.md',
 	description='A tool to read the job description example file.'


### PR DESCRIPTION
  Hi,João Moura.I am an undergraduate student at the University of Electronic Science and Technology of China. Recently I'm exploring your open source framework crewAi and try to experience the project job-posting.But I have encountered a minor 
issue that I wanted to bring to your attention. As you can see, In the latest submission of the crewAI-tools repository, the class name is defined as `SerperDevTool`, but in this repository, 
 it is incorrectly referenced as `SeperDevTool`.I believe this discrepancy might cause confusion or errors for those trying to use the framework. I appreciate your effort and dedication to this project, and I hope this feedback is helpful.
  It is my first pull request for a github project, a new try for me. What I hope is to continue to learn more useful knowledge from you, thank you.