### PR TITLE
fix: email_auto_responder flow

### DIFF
--- a/email_auto_responder_flow/src/email_auto_responder_flow/main.py
+++ b/email_auto_responder_flow/src/email_auto_responder_flow/main.py
@@ -20,7 +20,7 @@ class AutoResponderState(BaseModel):
 class EmailAutoResponderFlow(Flow[AutoResponderState]):
     initial_state = AutoResponderState
 
-    @start("wait_next_run")
+    @start("generate_draft_responses")
     def fetch_new_emails(self):
         print("Kickoff the Email Filter Crew")
         new_emails, updated_checked_email_ids = check_email(
@@ -50,7 +50,7 @@ async def run_flow():
     Run the flow.
     """
     email_auto_response_flow = EmailAutoResponderFlow()
-    email_auto_response_flow.kickoff()
+    await email_auto_response_flow.kickoff()
 
 
 async def plot_flow():

--- a/email_auto_responder_flow/src/email_auto_responder_flow/utils/emails.py
+++ b/email_auto_responder_flow/src/email_auto_responder_flow/utils/emails.py
@@ -35,12 +35,6 @@ def check_email(checked_emails_ids: set[str]) -> tuple[list[Email], set[str]]:
     return new_emails, checked_emails_ids
 
 
-def wait_next_run(state):
-    print("## Waiting for 180 seconds")
-    time.sleep(180)
-    return state
-
-
 def new_emails(state):
     if len(state["emails"]) == 0:
         print("## No new emails")


### PR DESCRIPTION
This PR apply two minor fixes to the email_auto_responder flow. 
- fix to run as a loop.
- fix async call to run flow.

It also removes an unused method (`wait_next_run`) in utils module.