### PR TITLE
fix: TOML prase error for Meta Quest Knowledge crew

### DIFF
--- a/meta_quest_knowledge/pyproject.toml
+++ b/meta_quest_knowledge/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "Meta Quest Knowledge"
+name = "meta_quest_knowledge"
 version = "0.1.0"
 description = "Knowledge Example using crewAI"
 authors = [{ name = "Mike Plachta", email = "mike@crewai.com" }]


### PR DESCRIPTION
"Meta Quest Knowledge" is not a valid or extra name. It results in TOML parse error.

```
Not a valid package or extra name: "Meta Quest Knowledge". Names must start and end with a letter or digit and may only contain -, _, ., and alphanumeric characters.
An error occurred while running the crew: Command '['uv', 'sync']' returned non-zero exit status 2.
```