### PR TITLE
Added .env.example file for meta_quest_knowledge

### DIFF
--- a/meta_quest_knowledge/.env.example
+++ b/meta_quest_knowledge/.env.example
@@ -1,0 +1,31 @@
+
+# .env.example — Rename this to `.env` and fill in your API keys to get started
+
+# API Keys
+
+# Optional: Uncomment and set if using a custom OpenAI API base
+# OPENAI_API_KEY=your-openai-api-key
+# OPENAI_API_BASE=https://api.openai.com/v1
+
+# Optional: Uncomment and set if using Serper for search capabilities
+# SERPER_API_KEY=your-serper-api-key
+
+# Optional: Uncomment and set if using Anthropic's Claude models
+# ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# Optional: Uncomment and set if using Groq's API
+# GROQ_API_KEY=your-groq-api-key
+
+# Optional: Uncomment and set if using Ollama locally
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODELS=ollama/llama3.1
+
+# Optional: Uncomment and set if using AgentOps
+# AGENTOPS_API_KEY=your-agentops-api-key
+# AGENTOPS_ENABLED=False
+
+# Optional: Uncomment and set if using XAI's API
+# XAI_API_KEY=your-xai-api-key
+
+# Optional: Uncomment and set if connecting to a PostgreSQL database
+# DB_URL=postgresql://crewai_user:secret@db:5432/crewai


### PR DESCRIPTION
## Issue

The `meta_quest_knowledge` project under the `crewAI-examples` repository requires environment variables to run, but a sample `.env.example` file was missing.

## Fix

Added a `.env.example` file with necessary placeholders for environment variables, including Ollama configuration and placeholders for other relevant APIs such as **OpenAI**, **Serper**, **Anthropic**, **Groq**, **AgentOps**, **XAI**, and **PostgreSQL**. The file aims to streamline the setup process for developers and users by offering a ready-to-use example configuration.
 